### PR TITLE
remove pycache

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
 ├── report.md
 ├── requirements.txt
 └── src
-    ├── __pycache__
-    │   ├── analysis.cpython-312.pyc
-    │   └── utils.cpython-312.pyc
     ├── analysis.py
     └── utils.py
 ```


### PR DESCRIPTION
Updated the project structure in the README to exclude the __pycache__ directory, ensuring a cleaner and more accurate representation of the project files.